### PR TITLE
Adds missing href to Link component

### DIFF
--- a/src/components/menu/link/Link.js
+++ b/src/components/menu/link/Link.js
@@ -8,7 +8,11 @@ function Link(props) {
         activeClass = styles.active;
     }
 
-    return <a className={`${styles.link} ${activeClass}`}>{props.children}</a>;
+    return (
+        <a href={props.href} className={`${styles.link} ${activeClass}`}>
+            {props.children}
+        </a>
+    );
 }
 
 export default Link;


### PR DESCRIPTION
This was causing the anchor link to not render out correctly due to the missing href.